### PR TITLE
Raise TypeError in instantiate_compressers if trying to infer compression from a file-like object

### DIFF
--- a/compress_pickle/utils.py
+++ b/compress_pickle/utils.py
@@ -105,10 +105,20 @@ def instantiate_compresser(
     BaseCompresser
         The compresser instance that will be used to create the byte stream from which a
         :class:`compress_pickle.picklers.base.BasePicklerIO` will read or write serialized objects.
+
+    Raises
+    ------
+    TypeError
+        If the supplied ``path`` is not a ``PATH_TYPES`` instance and the ``compression`` is "infer".
     """
     if isinstance(path, PATH_TYPES):
         _path = _stringyfy_path(path)
     if compression == "infer":
+        if not isinstance(path, PATH_TYPES):
+            raise TypeError(
+                f"Cannot infer the compression from a path that is not an instance of "
+                f"{PATH_TYPES}. Encountered {type(path)}"
+            )
         compression = _infer_compression_from_path(_path)
     compresser_class = get_compresser(compression)
     if set_default_extension and isinstance(path, PATH_TYPES):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from compress_pickle.utils import (
     _stringyfy_path,
     _infer_compression_from_path,
     _set_default_extension,
+    instantiate_compresser,
 )
 
 
@@ -52,6 +53,15 @@ def test_infer_compression_from_path_io_type():
     ):
         with io.BytesIO() as path:
             _infer_compression_from_path(path)
+
+
+def test_instantiate_compresser_cannot_infer_compression():
+    with pytest.raises(
+        TypeError,
+        match="Cannot infer the compression from a path that is not an instance of ",
+    ):
+        with io.BytesIO() as path:
+            instantiate_compresser(compression="infer", path=path, mode="rb")
 
 
 # def test_known_compressions():


### PR DESCRIPTION
This closes #33 and #34

It ensures that the correct exception is raised when trying to instantiate a compresser from a file-like object with the "infer" compression protocol.