### PR TITLE
Minor fixes for messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 environment.yml
 testing-report.html
 pip-wheel-metadata/*
+.gitignore.local
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/compress_pickle/compressers/registry.py
+++ b/compress_pickle/compressers/registry.py
@@ -52,7 +52,7 @@ class _compresser_registry:
             return cls._compresser_registry[compression]
         except Exception:
             raise ValueError(
-                f"Unknown compresser {compression}. "
+                f"Unknown compresser {repr(compression)}. "
                 f"Available values are {list(cls._compresser_registry)}"
             )
 
@@ -106,7 +106,7 @@ class _compresser_registry:
             return cls._compression_extension_map[extension.lstrip(".")]
         except Exception:
             raise ValueError(
-                f"Unregistered extension {extension}. "
+                f"Unregistered extension {repr(extension)}. "
                 f"Registered extensions are {list(cls._compression_extension_map)}"
             )
 
@@ -154,7 +154,7 @@ class _compresser_registry:
         """
         if compression in cls._compresser_registry:
             raise ValueError(
-                f"A compresser with name {compression} is already registered. "
+                f"A compresser with name {repr(compression)} is already registered. "
                 "Please choose a different name."
             )
         try:
@@ -169,9 +169,9 @@ class _compresser_registry:
         for ext in extensions:
             if ext in cls._compression_extension_map:
                 raise ValueError(
-                    f"Tried to register the extension {ext} to compresser {compression}, but it "
+                    f"Tried to register the extension {repr(ext)} to compresser {compression}, but it "
                     "is already registered in favour of compresser "
-                    f"{cls._compression_extension_map[ext]}. Please use a different extension "
+                    f"{repr(cls._compression_extension_map[ext])}. Please use a different extension "
                     "instead."
                 )
         cls._compresser_registry[compression] = compresser
@@ -181,7 +181,7 @@ class _compresser_registry:
 
     @classmethod
     def get_compression_write_mode(cls, compression: Optional[str]) -> str:
-        """Get the compression's default mode for openning the file buffer for writing.
+        """Get the compression's default mode for opening the file buffer for writing.
 
         Parameters
         ----------
@@ -203,13 +203,13 @@ class _compresser_registry:
         except Exception:  # pragma: no cover
             raise ValueError(
                 "Unknown compression {}. Available values are: {}".format(
-                    compression, list(cls._compresser_default_write_modes)
+                    repr(compression), list(cls._compresser_default_write_modes)
                 )
             )
 
     @classmethod
     def get_compression_read_mode(cls, compression: Optional[str]) -> str:
-        """Get the compression's default mode for openning the file buffer for reading.
+        """Get the compression's default mode for opening the file buffer for reading.
 
         Parameters
         ----------
@@ -231,7 +231,7 @@ class _compresser_registry:
         except Exception:  # pragma: no cover
             raise ValueError(
                 "Unknown compression {}. Available values are: {}".format(
-                    compression, list(cls._compresser_default_read_modes)
+                    repr(compression), list(cls._compresser_default_read_modes)
                 )
             )
 
@@ -254,12 +254,12 @@ class _compresser_registry:
         """
         if alias in cls._compresser_registry:
             raise ValueError(
-                f"The alias {alias} is already registered, please choose a different alias."
+                f"The alias {repr(alias)} is already registered, please choose a different alias."
             )
         if compression not in cls._compresser_registry:
             raise ValueError(
                 "Unknown compression {}. Available values are: {}".format(
-                    compression, list(cls._compresser_registry)
+                    repr(compression), list(cls._compresser_registry)
                 )
             )
         cls._compresser_registry[alias] = cls._compresser_registry[compression]
@@ -335,7 +335,7 @@ def validate_compression(compression: Optional[str], infer_is_valid: bool = True
         return True
     raise ValueError(
         "Unknown compression {}. Available values are: {}".format(
-            compression, get_known_compressions()
+            repr(compression), get_known_compressions()
         )
     )
 

--- a/compress_pickle/picklers/registry.py
+++ b/compress_pickle/picklers/registry.py
@@ -37,8 +37,8 @@ class _pickler_registry:
             return cls._pickler_registry[name]
         except Exception:
             raise ValueError(
-                f"Unknown pickler {name}. "
-                "Available values are {list(cls._pickler_registry)}"
+                f"Unknown pickler {repr(name)}. "
+                f"Available values are {list(cls._pickler_registry)}"
             )
 
     @classmethod
@@ -67,7 +67,7 @@ class _pickler_registry:
         """
         if name in cls._pickler_registry:
             raise ValueError(
-                f"A pickler with name {name} is already registered. "
+                f"A pickler with name {repr(name)} is already registered. "
                 "Please choose a different name."
             )
         try:
@@ -99,12 +99,12 @@ class _pickler_registry:
         """
         if alias in cls._pickler_registry:
             raise ValueError(
-                f"The alias {alias} is already registered, please choose a different alias."
+                f"The alias {repr(alias)} is already registered, please choose a different alias."
             )
         if pickler not in cls._pickler_registry:
             raise ValueError(
                 "Unknown pickler name {}. Available values are: {}".format(
-                    pickler, list(cls._pickler_registry)
+                    repr(pickler), list(cls._pickler_registry)
                 )
             )
         cls._pickler_registry[alias] = cls._pickler_registry[pickler]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,5 @@ sphinx-autobuild==0.7.1
 sphinx>=1.5.5
 cloud_sptheme
 numpy
+cloudpickle
+dill

--- a/tests/test_compresser_registry.py
+++ b/tests/test_compresser_registry.py
@@ -28,7 +28,7 @@ def test_compresser_registry():
             pass
 
         with pytest.raises(
-            ValueError, match=f"Unknown compresser {name}. Available values are "
+            ValueError, match=f"Unknown compresser {name!r}. Available values are "
         ):
             get_compresser(name)
         register_compresser(
@@ -51,7 +51,7 @@ def test_compresser_registry():
             register_compresser("mock2", proxy, extensions=["mock"])
         with pytest.raises(
             ValueError,
-            match=f"A compresser with name {name} is already registered. Please choose a ",
+            match=f"A compresser with name {name!r} is already registered. Please choose a ",
         ):
             register_compresser(name, proxy, extensions)
     finally:
@@ -72,7 +72,7 @@ def test_validate_compression(compressions_to_validate):
     if expected_fail:
         with pytest.raises(
             ValueError,
-            match=re.escape(f"Unknown compression {compression}. Available values are"),
+            match=re.escape(f"Unknown compression {compression!r}. Available values are"),
         ):
             validate_compression(compression, infer_is_valid=infer_is_valid)
     else:
@@ -117,7 +117,7 @@ def test_aliasing():
         pass
 
     with pytest.raises(
-        ValueError, match=f"Unknown compression {name}. Available values are:"
+        ValueError, match=f"Unknown compression {name!r}. Available values are:"
     ):
         add_compression_alias(
             alias,
@@ -142,7 +142,7 @@ def test_aliasing():
         assert _compresser_registry._compression_aliases[alias] == name
 
         with pytest.raises(
-            ValueError, match=f"The alias {alias} is already registered"
+            ValueError, match=f"The alias {alias!r} is already registered"
         ):
             add_compression_alias(
                 alias,

--- a/tests/test_picklers_registry.py
+++ b/tests/test_picklers_registry.py
@@ -21,7 +21,7 @@ def test_compresser_registry():
             pass
 
         with pytest.raises(
-            ValueError, match=f"Unknown pickler {name}. Available values are "
+            ValueError, match=f"Unknown pickler {name!r}. Available values are "
         ):
             get_pickler(name)
         register_pickler(
@@ -31,7 +31,7 @@ def test_compresser_registry():
         assert get_pickler(name) is proxy
         with pytest.raises(
             ValueError,
-            match=f"A pickler with name {name} is already registered. Please choose a ",
+            match=f"A pickler with name {name!r} is already registered. Please choose a ",
         ):
             register_pickler(name, proxy)
     finally:
@@ -48,7 +48,7 @@ def test_validate_picklers(picklers_to_validate):
     if expected_fail:
         with pytest.raises(
             ValueError,
-            match=re.escape(f"Unknown pickler {name}. Available values are"),
+            match=re.escape(f"Unknown pickler {name!r}. Available values are"),
         ):
             get_pickler(name)
     else:
@@ -59,7 +59,7 @@ def test_register_wrong_type():
     pickler = object
     with pytest.raises(
         TypeError,
-        match=re.escape(f"The supplied pickler {pickler} is not a derived from "),
+        match=re.escape(f"The supplied pickler {pickler!r} is not a derived from "),
     ):
         register_pickler(
             name="mock_pickler",
@@ -75,7 +75,7 @@ def test_aliasing():
         pass
 
     with pytest.raises(
-        ValueError, match=f"Unknown pickler name {name}. Available values are:"
+        ValueError, match=f"Unknown pickler name {name!r}. Available values are:"
     ):
         add_pickler_alias(
             alias,
@@ -95,7 +95,7 @@ def test_aliasing():
         assert _pickler_registry._pickler_aliases[alias] == name
 
         with pytest.raises(
-            ValueError, match=f"The alias {alias} is already registered"
+            ValueError, match=f"The alias {alias!r} is already registered"
         ):
             add_pickler_alias(
                 alias,


### PR DESCRIPTION
This includes some small fixes, such as a missing 'f' for an f-string, quoting strings in error output for clarity, and the like.

Examples:
 * Unknown compresser lzo
   * becomes: Unknown compresser "lzo"
 * "Openning" becomes "Opening"
 * Unknown pickler foo. Available values are {list(cls._pickler_registry)}
   * becomes: Unknown pickler "foo". Available values are ["bar", "baz", "bat"]

Exceptions:
  * Because it is a module name, "compresser" is not changed to "compressor", and all spellings of the word are left as-is.

Different project leaders prefer different PR styles.  If you find it acceptable, I'll just include these kinds of changes in with my other, code-related PRs.   If you'd rather, though, I can keep spelling/message PRs separate from code PRs, as I have this one.  Please inform!