### PR TITLE
Add .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# VS Code project data
+.vscode
+
 # Rope project settings
 .ropeproject
 


### PR DESCRIPTION
How about ignoring the config/data dir for VS Code, too? This subdir gets auto-created when I open the repo folder in VS Code.